### PR TITLE
Configurable default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ $ ember serve
 ```
 
 ### Configuration
+
+#### Style
+
 Using **SASS** makes configuring the color scheme simple. Just make sure you import `components/color` and `components/variables` before `materialize` like the example below.
 
 ```scss
@@ -49,6 +52,25 @@ $primary-color: color("pink", "lighten-2");
 ```
 See the materialize docs on sass variables [here](http://materializecss.com/color.html).
 
+#### Defaults
+
+Some of the library's defaults can be set via your **config/environment.js** file
+
+```javascript
+module.exports = function(/* environment, appConfig */) {
+  var ENV = {
+    materializeDefaults: {
+      modalIsFooterFixed: false,
+      buttonIconPosition: 'left',
+      loaderSize:         'big',
+      loaderMode:         'indeterminate',
+      modalContainerId:   'materialize-modal-root-element'
+    },
+    ...
+  };
+}
+
+```
 
 ## Installation
 

--- a/addon/components/md-btn.js
+++ b/addon/components/md-btn.js
@@ -1,15 +1,18 @@
 import Ember from 'ember';
+import UsesSettings from '../mixins/uses-settings';
 import layout from '../templates/components/md-btn';
 import computed from 'ember-new-computed';
 
-export default Ember.Component.extend({
+const { computed: { oneWay } } = Ember;
+
+export default Ember.Component.extend(UsesSettings, {
   layout: layout,
   tagName: 'a',
   classNameBindings: ['btn:waves-effect', 'isFlat::waves-light', 'isDisabled:disabled:waves-effect', 'buttonClass'],
   attributeBindings: ['isDisabled:disabled'],
   text: null,
   icon: null,
-  iconPosition: 'left',
+  iconPosition: oneWay('_mdSettings.buttonIconPosition'),
   buttonType: null,
   actionArg: null,
   isFlat: Ember.computed.equal('buttonType', 'flat'),

--- a/addon/components/md-loader.js
+++ b/addon/components/md-loader.js
@@ -1,15 +1,18 @@
 import Ember from 'ember';
+import UsesSettings from '../mixins/uses-settings';
 import layout from '../templates/components/md-loader';
 import computed from 'ember-new-computed';
 
-export default Ember.Component.extend({
+const { computed: { oneWay } } = Ember;
+
+export default Ember.Component.extend(UsesSettings, {
   layout: layout,
 
   classNameBindings: ['isBarType:progress:preloader-wrapper', 'active:active', 'size'],
 
-  mode: 'indeterminate',
+  mode: oneWay('_mdSettings.loaderMode'),
   percent: 0,
-  size: 'big',
+  size: oneWay('_mdSettings.loaderSize'),
   active: true,
   color: null,
 

--- a/addon/components/md-modal-container.js
+++ b/addon/components/md-modal-container.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
+import UsesSettings from '../mixins/uses-settings';
 import layout from '../templates/components/md-modal-container';
 
-export default Ember.Component.extend({
-  modalContainerId: 'materialize-modal-root-element',
+const { computed: { oneWay } } = Ember;
+
+export default Ember.Component.extend(UsesSettings, {
+  modalContainerId: oneWay('_mdSettings.modalContainerId'),
   layout: layout
 });

--- a/addon/components/md-modal.js
+++ b/addon/components/md-modal.js
@@ -1,8 +1,12 @@
+import Ember from 'ember';
+import UsesSettings from '../mixins/uses-settings';
 import YappModal from 'ember-modal-dialog/components/modal-dialog';
 import layout from '../templates/components/md-modal';
 import computed from 'ember-new-computed';
 
-export default YappModal.extend({
+const { computed: { oneWay } } = Ember;
+
+export default YappModal.extend(UsesSettings, {
   layout: layout,
 
   destinationElementId: "materialize-modal-root-element",
@@ -17,13 +21,13 @@ export default YappModal.extend({
     }
   }),
 
-  fixedFooter: false,
+  isFooterFixed: oneWay('_mdSettings.modalIsFooterFixed'),
 
   modalClassNames: ['modal', 'show'],
-  _modalClassString: computed('modalClassNames.@each', 'fixedFooter', {
+  _modalClassString: computed('modalClassNames.@each', 'isFooterFixed', {
     get() {
       let names = this.get('modalClassNames');
-      if (this.get('fixedFooter')) {
+      if (this.get('isFooterFixed')) {
         names.push('modal-fixed-footer');
       }
       return names.join(' ');

--- a/addon/components/md-modal.js
+++ b/addon/components/md-modal.js
@@ -9,10 +9,24 @@ export default YappModal.extend({
   acceptsKeyResponder: true,
   overlayId: 'lean-modal',
   attributeBindings: ['style:inlineStyle'],
+  concatenatedProperties: ['modalClassNames'],
 
   inlineStyle: computed({
     get() {
       return 'z-index: 1000;';
+    }
+  }),
+
+  fixedFooter: false,
+
+  modalClassNames: ['modal', 'show'],
+  _modalClassString: computed('modalClassNames.@each', 'fixedFooter', {
+    get() {
+      let names = this.get('modalClassNames');
+      if (this.get('fixedFooter')) {
+        names.push('modal-fixed-footer');
+      }
+      return names.join(' ');
     }
   }),
 

--- a/addon/components/md-modal.js
+++ b/addon/components/md-modal.js
@@ -9,7 +9,8 @@ const { computed: { oneWay } } = Ember;
 export default YappModal.extend(UsesSettings, {
   layout: layout,
 
-  destinationElementId: "materialize-modal-root-element",
+  destinationElementId: oneWay('_mdSettings.modalContainerId'),
+
   acceptsKeyResponder: true,
   overlayId: 'lean-modal',
   attributeBindings: ['style:inlineStyle'],

--- a/addon/mixins/uses-settings.js
+++ b/addon/mixins/uses-settings.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import computed from 'ember-new-computed';
+
+export default Ember.Mixin.create({
+  _mdSettings: computed({
+    get() {
+      return this.get('container').lookup('service:materialize-settings');
+    }
+  })
+});

--- a/addon/services/md-settings.js
+++ b/addon/services/md-settings.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+const { keys, getWithDefault, set, computed: { oneWay } } = Ember;
+const { classify } = Ember.String;
+
+export default Ember.Service.extend({
+  // Footer
+  modalIsFooterFixed: oneWay('defaultModalIsFooterFixed'),
+  // Button
+  buttonIconPosition: oneWay('defaultButtonIconPosition'),
+  // Loader
+  loaderSize: oneWay('defaultLoaderSize'),
+  loaderMode: oneWay('defaultLoaderMode'),
+  // Modal
+  modalContainerId: oneWay('defaultModalContainerId'),
+
+  init() {
+    this._super(...arguments);
+    this._setDefaults();
+  },
+
+  _setDefaults() {
+    const defaults = getWithDefault(this, 'materializeDefaults', {});
+    keys(defaults).map(key => {
+      const classifiedKey = classify(key);
+      const defaultKey = `default${classifiedKey}`;
+      return set(this, defaultKey, defaults[key]);
+    });
+  }
+});

--- a/addon/templates/components/md-modal.hbs
+++ b/addon/templates/components/md-modal.hbs
@@ -5,7 +5,7 @@
   {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString container-class"
                                 alignment=alignment
                                 alignmentTarget=alignmentTarget}}
-  <div class="modal show" style="display: block; opacity: 1; top: 10%;">
+  <div {{bind-attr class=_modalClassString}} style="display: block; opacity: 1; top: 10%;">
     {{yield}}
   </div>
   {{/ember-modal-dialog-positioned-container}}

--- a/app/initializers/md-settings.js
+++ b/app/initializers/md-settings.js
@@ -1,0 +1,15 @@
+import config from '../config/environment';
+import MaterializeSettings from 'ember-cli-materialize/services/md-settings';
+
+export function initialize(container, application) {
+  const { materializeDefaults } = config;
+
+  application.register('config:materialize', materializeDefaults, { instantiate: false });
+  application.register('service:materialize-settings', MaterializeSettings);
+  application.inject('service:materialize-settings', 'materializeDefaults', 'config:materialize');
+}
+
+export default {
+  name: 'md-settings',
+  initialize: initialize
+};

--- a/app/services/md-settings.js
+++ b/app/services/md-settings.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-materialize/services/md-settings';

--- a/blueprints/ember-cli-materialize/index.js
+++ b/blueprints/ember-cli-materialize/index.js
@@ -4,7 +4,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   beforeInstall: function(options) {
-    return this.addBowerPackageToProject('materialize', '~0.96.1');
+    return this.addBowerPackageToProject('materialize', '~0.97.0');
   },
 
   afterInstall: function() {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-materialize",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "~1.10.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
@@ -14,6 +14,7 @@
     "qunit": "~1.17.1"
   },
   "resolutions": {
-    "jquery": "^1.11.1"
+    "jquery": "^1.11.1",
+    "ember": "~1.10.0"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,10 +4,10 @@ module.exports = function(/* environment, appConfig */) {
   return {
     materializeDefaults: {
       modalIsFooterFixed: false,
+      modalContainerId: 'materialize-modal-root-element',
       buttonIconPosition: 'left',
       loaderSize: 'big',
-      loaderMode: 'indeterminate',
-      modalContainerId: 'materialize-modal-root-element'
+      loaderMode: 'indeterminate'
     }
   };
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,13 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+    materializeDefaults: {
+      modalIsFooterFixed: false,
+      buttonIconPosition: 'left',
+      loaderSize: 'big',
+      loaderMode: 'indeterminate',
+      modalContainerId: 'materialize-modal-root-element'
+    }
+  };
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-materialize",
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/unit/components/materialize-button-test.js
+++ b/tests/unit/components/materialize-button-test.js
@@ -1,3 +1,4 @@
+import MdSettings from 'ember-cli-materialize/services/md-settings';
 import Ember from 'ember';
 
 import {
@@ -45,7 +46,9 @@ test('button text test', function(assert) {
 });
 
 test('button icon test', function(assert) {
-  var component = this.subject();
+  var component = this.subject({
+    iconPosition: 'left'
+  });
   this.render();
 
   Ember.run(function(){

--- a/tests/unit/components/md-modal-container-test.js
+++ b/tests/unit/components/md-modal-container-test.js
@@ -26,7 +26,9 @@ test('it has the expected ID for md-modal to render into it', function(assert) {
   assert.expect(1);
 
   // Creates the component instance
-  var component = this.subject();
+  var component = this.subject({
+    modalContainerId: 'materialize-modal-root-element'
+  });
   // Renders the component to the page
   this.render();
   assert.equal(component.$('#materialize-modal-root-element').length, 1, '#materialize-modal-root-element should be in the DOM');

--- a/tests/unit/initializers/md-settings-test.js
+++ b/tests/unit/initializers/md-settings-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { initialize } from '../../../initializers/md-settings';
+import { module, test } from 'qunit';
+
+var container, application;
+
+module('Unit | Initializer | md settings', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      container = application.__container__;
+      application.deferReadiness();
+    });
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(container, application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});

--- a/tests/unit/services/md-settings-test.js
+++ b/tests/unit/services/md-settings-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:md-settings', 'Unit | Service | md settings', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Moving forward, any default values that might be useful to set on a per-app basis should be moved to a `md-settings` service. Consuming apps can then use their **config/environment.js** file to tweak as desired.


```js
module.exports = function(/* environment, appConfig */) {
  var ENV = {
    materializeDefaults: {
      modalIsFooterFixed: false,
      buttonIconPosition: 'left',
      loaderSize:         'big',
      loaderMode:         'indeterminate',
      modalContainerId:   'materialize-modal-root-element'
    },
    ...
  };
}
```