### PR TITLE
Removed blueprint temporary fix for materialize.css that is no longer

### DIFF
--- a/blueprints/ember-cli-materialize/files/app/styles/app.scss
+++ b/blueprints/ember-cli-materialize/files/app/styles/app.scss
@@ -1,9 +1,2 @@
 @import 'materialize';
 @import 'ember-cli-materialize';
-
-/* FIXME: Workaround for https://github.com/Dogfalo/materialize/issues/1079 */
-@each $mdi-icon-name, $mdi-icon-value in $mdi-list-icons {
-  .#{$mdi-prefix}#{$mdi-icon-name}:before {
-    content: "\""+ $mdi-icon-value +"\"";
-  }
-}


### PR DESCRIPTION
needed with materialize.css 0.97.  Fixes issue #171 