### PR TITLE
Remove Ember.keys deprecation warning

### DIFF
--- a/addon/services/md-settings.js
+++ b/addon/services/md-settings.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const { getWithDefault, set, computed: { oneWay } } = Ember;
 const { classify } = Ember.String;
-var keys = Object.keys || Ember.keys;
+const keys = Object.keys || Ember.keys;
 
 export default Ember.Service.extend({
   // Footer

--- a/addon/services/md-settings.js
+++ b/addon/services/md-settings.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 
-const { keys, getWithDefault, set, computed: { oneWay } } = Ember;
+const { getWithDefault, set, computed: { oneWay } } = Ember;
 const { classify } = Ember.String;
+var keys = Object.keys || Ember.keys;
 
 export default Ember.Service.extend({
   // Footer


### PR DESCRIPTION
Keeping IE8 compatibility, as per https://github.com/emberjs/data/issues/3465